### PR TITLE
use backticks to avoid escaping regex syntax

### DIFF
--- a/gotube.go
+++ b/gotube.go
@@ -237,7 +237,7 @@ func ParseStr(encodedString string, result map[string]interface{}) error {
 }
 
 func DownloadYTVideo(videoURL, outputDirectory string, verbose, audio bool) {
-	isMatch, _ := regexp.MatchString("https://www\\.youtube\\.com/watch\\?v=[\\w-]+", videoURL) // TODO need better regex pattern
+	isMatch, _ := regexp.MatchString(`https://www\.youtube\.com/watch\?v=[\w-]+`, videoURL) // TODO need better regex pattern
 
 	if !isMatch {
 		log.Fatal("GoTube: Invalid YouTube URL!")


### PR DESCRIPTION
**Problem**: string literal makes regex syntax more complicated due to escapement.
**Solution**: utilize a raw string literal (i.e. backtick string).