### PR TITLE
Add Travis CI for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+script: test -z $(gofmt -l gotube.go)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoTube
 
-![](https://img.shields.io/badge/build-passing-green)
+[![Build Status](https://api.travis-ci.com/Marethyu12/gotube.svg?branch=master)](https://travis-ci.com/Marethyu12/gotube)
 ![](https://img.shields.io/badge/version-v1.2-blue)
 
 ## Overview


### PR DESCRIPTION
Adds a simple Travis CI script for running `gofmt`. Now, the build badge on the readme will actually work once you activate Travis :)

See example build here: https://travis-ci.com/github/kx-chen/gotube/jobs/315607780

This also helps enforce gofmt on all commits, you can see the checkmark on the list of commits https://github.com/kx-chen/gotube/commits/add-travis-ci